### PR TITLE
Add aeon-datepicker web component

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,6 +43,7 @@ Frequently-solved problems in web component form.
 - [`<dark-mode-toggle>`](https://github.com/GoogleChromeLabs/dark-mode-toggle)
 - [`<katex-display>` and `<katex-inline>`](https://www.npmjs.com/package/katex-elements)
 - [`<html-include>`](https://www.npmjs.com/package//html-include-element)
+- [`<aeon-datepicker>`](https://github.com/lamplightdev/aeon)
 
 ## Novelty Elements
 


### PR DESCRIPTION
Adds a link to the Aeon date time picker that provides a consistent experience across platforms - lightweight, accessible, and falls back to the native browser picker if available and/or required.